### PR TITLE
Add support for timezone-aware datetimes, and pytz timezones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ ENV/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# PyCharm / IDEA project folder
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ notifications:
 before_install:
   # coverage submission packages
   - pip install codecov
+  # for testing timezone features
+  - pip install pytz tzlocal
 install:
   # Coveralls 4.0 doesn't support Python 3.2
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi

--- a/morejson/core.py
+++ b/morejson/core.py
@@ -127,7 +127,6 @@ def _timezone_encoder(obj, dt=None):
         _MOREJSON_TYPE: _EncodedTypes.TIMEZONE,
         'offset': obj.utcoffset(dt),
         'name': obj.tzname(dt),
-
     }
     if allow_pickle():
         # Hacky, but this allows us to restore the exact class that was used
@@ -190,6 +189,8 @@ class _EncodedTypes(object):
     TIMEDELTA = 'datetime.timedelta'
     TIMEZONE = 'datetime.timezone'
     PYTZ_TIMEZONE = 'pytz.tzinfo.BaseTzInfo'
+    PYTZ_FIXEDOFFSET = 'pytz.FixedOffset'
+    PYTZ_UTC = 'pytz.UTC'
     SET = 'set'
     FROZENSET = 'frozenset'
     COMPLEX = 'complex'
@@ -228,6 +229,17 @@ if pytz is not None:
     # necessary a different decoder could be used if they need to be split off.
     _ENCODER_MAP[pytz.tzinfo.BaseTzInfo] = _timezone_encoder
     _DECODER_MAP[_EncodedTypes.PYTZ_TIMEZONE] = _timezone_decoder
+
+    # Pytz's UTC and FixedOffset class don't have the same base class as the others.
+    _ENCODER_MAP[pytz.UTC.__class__] = _timezone_encoder
+    _DECODER_MAP[_EncodedTypes.PYTZ_UTC] = _timezone_decoder
+
+    _ENCODER_MAP[pytz._FixedOffset] = _timezone_encoder
+    _DECODER_MAP[_EncodedTypes.PYTZ_FIXEDOFFSET] = _timezone_decoder
+
+    # With Python 2.7 and pytz installed, we can decode "_EncodedTypes.TIMEZONE" with above types, but can't
+    # encode `datetime.timezone` itself since it doesn't exist.
+    _DECODER_MAP[_EncodedTypes.TIMEZONE] = _timezone_decoder
 
 
 def _morejson_object_hook(dict_obj):

--- a/morejson/core.py
+++ b/morejson/core.py
@@ -138,7 +138,7 @@ def _timezone_encoder(obj, dt=None):
 def _timezone_decoder(dict_obj):
     pickle_str = dict_obj.pop("__pickle__", None)
     if allow_pickle() and pickle_str:
-        return pickle.loads(binascii.a2b_base64(pickle_str))
+        return pickle.loads(binascii.a2b_base64(pickle_str.encode("ascii")))
     return datetime.timezone(**dict_obj)
 
 

--- a/morejson/core.py
+++ b/morejson/core.py
@@ -24,7 +24,7 @@ except ImportError:
 
 try:
     import pytz
-except ImportError:
+except ImportError:  # pragma: no cover
     # This installation doesn't have pytz, so we can ignore it
     pytz = None
 
@@ -240,6 +240,8 @@ if pytz is not None:
     # With Python 2.7 and pytz installed, we can decode "_EncodedTypes.TIMEZONE" with above types, but can't
     # encode `datetime.timezone` itself since it doesn't exist.
     _DECODER_MAP[_EncodedTypes.TIMEZONE] = _timezone_decoder
+else:  # pragma: no cover
+    pass
 
 
 def _morejson_object_hook(dict_obj):

--- a/morejson/core.py
+++ b/morejson/core.py
@@ -1,8 +1,11 @@
 """Core functionalities for morejson."""
 
+import binascii
 import datetime
 import inspect
 import json
+import pickle
+# noinspection PyUnresolvedReferences
 from json import (  # pylint: disable=W0611
     decoder,
     encoder,
@@ -19,6 +22,11 @@ try:
 except ImportError:
     pass # we're on Python 2/3.4 or below
 
+try:
+    import pytz
+except ImportError:
+    # This installation doesn't have pytz, so we can ignore it
+    pytz = None
 
 # partly based on a great git gist by abhinav-upadhyay:
 # https://gist.github.com/abhinav-upadhyay/5300137
@@ -60,7 +68,7 @@ def _time_decoder(dict_obj):
 # === datetime ===
 
 def _datetime_encoder(obj):
-    return {
+    rv = {
         _MOREJSON_TYPE : _EncodedTypes.DATETIME,
         'year' : obj.year,
         'month' : obj.month,
@@ -70,6 +78,10 @@ def _datetime_encoder(obj):
         'second' : obj.second,
         'microsecond' : obj.microsecond,
     }
+    if obj.tzinfo:
+        rv["tzinfo"] = _timezone_encoder(obj.tzinfo, dt=obj)
+    return rv
+
 
 def _datetime_decoder(dict_obj):
     return datetime.datetime(**dict_obj)
@@ -91,14 +103,42 @@ def _timedelta_decoder(dict_obj):
 
 # === timezone ===
 
-def _timezone_encoder(obj):
-    return {
-        _MOREJSON_TYPE : _EncodedTypes.TIMEZONE,
-        'offset' : obj.utcoffset(datetime.datetime.now()),
-        'name' : obj.tzname(datetime.datetime.now())
+# Pickle can be used to restore the exact class originally used by the timezone,
+# but is potentially dangerous when accepting input from an untrusted source. Therefore it is
+# disabled by default here. Without CONFIG['allow_pickle'] == True, a roundtrip with a pytz zone
+# would turn it into a generic datetime.timezone with the same offset. That may be sufficient for
+#  many purposes, but for example, it causes the unit test to fail because the input and output
+# are different (though equivalent) classes. So if you need the exact TZ class returned in a
+# roundtrip, you can set allow_pickle=True, but be wary of accepting JSON from untrusted sources.
+
+CONFIG = {
+    "allow_pickle": False,
+}
+
+
+def allow_pickle():
+    return CONFIG.get("allow_pickle", False)
+
+
+def _timezone_encoder(obj, dt=None):
+    if dt is None:
+        dt = datetime.datetime.now()
+    rv = {
+        _MOREJSON_TYPE: _EncodedTypes.TIMEZONE,
+        'offset': obj.utcoffset(dt),
+        'name': obj.tzname(dt),
+
     }
+    if allow_pickle():
+        # Hacky, but this allows us to restore the exact class that was used
+        rv['__pickle__'] = binascii.b2a_base64(pickle.dumps(obj)).decode("ascii").strip()
+    return rv
+
 
 def _timezone_decoder(dict_obj):
+    pickle_str = dict_obj.pop("__pickle__", None)
+    if allow_pickle() and pickle_str:
+        return pickle.loads(binascii.a2b_base64(pickle_str))
     return datetime.timezone(**dict_obj)
 
 
@@ -149,6 +189,7 @@ class _EncodedTypes(object):
     DATETIME = 'datetime.datetime'
     TIMEDELTA = 'datetime.timedelta'
     TIMEZONE = 'datetime.timezone'
+    PYTZ_TIMEZONE = 'pytz.tzinfo.BaseTzInfo'
     SET = 'set'
     FROZENSET = 'frozenset'
     COMPLEX = 'complex'
@@ -180,6 +221,15 @@ except AttributeError:
     pass  # we're on Python 2.x
 
 
+if pytz is not None:
+    # pytz uses a different class for each zone, so we need the map key to be the base class
+    # BaseTzInfo. Currently, pytz uses the same encoder/decoder as for 'datetime.timezone' as
+    # well as the same __type__ - so you won't see PYTZ_TIMEZONE in the actual JSON. However if
+    # necessary a different decoder could be used if they need to be split off.
+    _ENCODER_MAP[pytz.tzinfo.BaseTzInfo] = _timezone_encoder
+    _DECODER_MAP[_EncodedTypes.PYTZ_TIMEZONE] = _timezone_decoder
+
+
 def _morejson_object_hook(dict_obj):
     try:
         if _MOREJSON_TYPE not in dict_obj:
@@ -203,7 +253,10 @@ def _get_wrapped_morejson_hook(custom_hook):
 
 def _morejson_default_encoder(obj): # pylint: disable=E0202
     try:
-        return _ENCODER_MAP[type(obj)](obj)
+        enc_key = type(obj)
+        if pytz is not None and isinstance(obj, pytz.tzinfo.BaseTzInfo):
+            enc_key = pytz.tzinfo.BaseTzInfo
+        return _ENCODER_MAP[enc_key](obj)
     except KeyError:
         raise TypeError("Type {} is not JSON encodable.".format(type(obj)))
 

--- a/morejson/core.py
+++ b/morejson/core.py
@@ -222,7 +222,7 @@ except AttributeError:
     pass  # we're on Python 2.x
 
 
-if pytz is not None:
+if pytz is not None:  # pragma: no branch
     # pytz uses a different class for each zone, so we need the map key to be the base class
     # BaseTzInfo. Currently, pytz uses the same encoder/decoder as for 'datetime.timezone' as
     # well as the same __type__ - so you won't see PYTZ_TIMEZONE in the actual JSON. However if
@@ -240,8 +240,6 @@ if pytz is not None:
     # With Python 2.7 and pytz installed, we can decode "_EncodedTypes.TIMEZONE" with above types, but can't
     # encode `datetime.timezone` itself since it doesn't exist.
     _DECODER_MAP[_EncodedTypes.TIMEZONE] = _timezone_decoder
-else:  # pragma: no cover
-    pass
 
 
 def _morejson_object_hook(dict_obj):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=['morejson'],
     # packages=find_packages(),
     install_requires=[],
-    setup_requires=['nose', 'coverage', 'nose-timer'],
+    setup_requires=['nose', 'coverage', 'nose-timer', 'pytz', 'tzlocal'],
     test_suite='nose.collector',
     platforms=['any'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     packages=['morejson'],
     # packages=find_packages(),
     install_requires=[],
-    setup_requires=['nose', 'coverage', 'nose-timer', 'pytz', 'tzlocal'],
+    setup_requires=[],
+    tests_require=['nose', 'coverage', 'nose-timer', 'pytz', 'tzlocal'],
     test_suite='nose.collector',
     platforms=['any'],
     classifiers=[

--- a/tests/test_dumps_loads.py
+++ b/tests/test_dumps_loads.py
@@ -149,13 +149,6 @@ class TestDumps(unittest.TestCase):
         Testing dumps and loads of timezone-aware datetime types, with custom defined (fixed offset from UTC) zones.
         This uses the `datetime.timezone` class which is not available on Python 2.7, so we skip it there.
         """
-        try:
-            import pytz
-            import tzlocal
-        except ImportError:
-            # These packages aren't available - can't test
-            raise unittest.SkipTest(
-                "pytz or tzlocal not available in this test run; skipping zone-aware DT tests.")
 
         custom_tz = datetime.timezone(datetime.timedelta(hours=-8, minutes=-30))
         UTC = datetime.timezone.utc

--- a/tests/test_dumps_loads.py
+++ b/tests/test_dumps_loads.py
@@ -104,6 +104,37 @@ class TestDumps(unittest.TestCase):
         }
         self.assertEqual(dicti, morejson.loads(morejson.dumps(dicti)))
 
+    def test_dumps_datetime_with_zone(self):
+        """Testing dumps and loads of timezone-aware datetime types, as well as standalone 
+        timezone objects """
+
+        import pytz
+        import tzlocal
+
+        local_tz = tzlocal.get_localzone()
+        custom_tz = datetime.timezone(datetime.timedelta(hours=-8, minutes=-30))
+        pytz_est = pytz.timezone("US/Eastern")
+
+        original_allow_pickle = morejson.CONFIG.get("allow_pickle", False)
+        morejson.CONFIG["allow_pickle"] = True
+
+        dicti = {
+            'datetime-no-tz': datetime.datetime.now(),
+            'datetime-with-utc': datetime.datetime.now(tz=datetime.timezone.utc),
+            'datetime-with-est': datetime.datetime.now(tz=pytz_est),
+            'datetime-with-tzlocal': datetime.datetime.now(tz=local_tz),
+            'datetime-with-tz-plain': datetime.datetime.now(tz=custom_tz),
+            'eastern-tzone': pytz_est,
+            'custom-tzone': custom_tz,
+            'array': [1, 2, 3, pytz_est],
+            'string': 'trololo',
+            'null': None
+        }
+        out_str = morejson.dumps(dicti)
+        actual_obj = morejson.loads(out_str)
+        self.assertEqual(dicti, actual_obj)
+        morejson.CONFIG["allow_pickle"] = original_allow_pickle
+
     def test_dumps_set(self):
         """Testing dumps and loads of set types."""
         dicti = {


### PR DESCRIPTION
This adds support for timezone-aware datetimes and pytz based timezone objects. 

See: https://github.com/shaypal5/morejson/issues/1